### PR TITLE
Add per-frame zoom controls that persist

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,6 +60,12 @@ When adding new keyboard shortcuts:
 - Ensure shortcuts don't interfere with text input fields by using the main window context
 - Document new shortcuts in both `README.md` and this file
 
+## Frame Scale Controls
+- Each frame header exposes `A-`, `A+`, and `1x` buttons that zoom only the embedded `QWebEngineView`. The header chrome intentionally stays a constant size so controls remain predictable; under the hood the buttons call `SplitFrameWidget::setScaleFactor`, which forwards the value to `QWebEngineView::setZoomFactor`.
+- Matching View menu actions (`Increase/Decrease/Reset Frame Scale`) operate on the currently focused frame for accessibility and keyboard-driven workflows. Add future shortcuts to those actions, not to individual widgets.
+- Scale factors are persisted per frame alongside addresses under the `frameScales` key in `QSettings`. Whenever you add, remove, or reorder frames, update the paired scale vector so indices remain aligned. Migrating persistence logic must keep both lists backward compatible.
+- If you need traditional web zoom outside of this mechanism, avoid duplicating state—route everything through `setScaleFactor` so persistence and UI stay consistent.
+
 ## Web View Context Menu
 - Navigation actions (Back, Forward, Reload) and editing commands (Cut, Copy, Paste, Select All) mirror Qt's built-in `QWebEnginePage` actions.
 - **Copy Link Address** appears when right-clicking a hyperlink and copies the fully encoded target URL to the clipboard for easy sharing.

--- a/README.md
+++ b/README.md
@@ -51,6 +51,11 @@ cmake --build . --config Release
 - Each section is equally sized using layout stretch factors
 - Use the Layout menu to switch between Grid, Vertical, and Horizontal arrangements
 
+### Per-frame zoom controls
+- Use the `A-`, `A+`, and `1x` buttons in each frame header (or `View -> Increase/Decrease/Reset Frame Scale`) to zoom the embedded page without touching splitter sizes or header chrome. These controls are simply a shortcut for adjusting the QWebEngineView zoom on a frame-by-frame basis.
+- The UI chrome stays at a consistent size so controls remain easy to target even when a page is zoomed way in/out.
+- Zoom choices are stored per frame in the current layout. Closing and reopening the app restores the last zoom factor for each saved slot.
+
 ## DOM Patches
 
 This application supports persisting small DOM CSS "patches" you create while using the inspector.  
@@ -150,3 +155,38 @@ Artifacts are retained for 90 days. The workflow can also be triggered manually 
 ## BUGS
 - Discord page blank white
 - messenger.com page not loading
+
+## Tests
+
+Acceptance tests / expected behavior
+---------------------------------
+These tests define the desired behavior for layout selection and splitter persistence.
+
+1) Setting a layout
+	- Action: Select a layout from the `Layout` menu (Grid, Stack Vertically, Stack Horizontally).
+	- Expected: The UI rebuilds so all frames are visible and equally sized.
+
+2) Manually adjusting splitters
+	- Action: Drag a splitter handle to change sizes of adjacent frames.
+	- Expected: The UI updates immediately to reflect the new sizes. The new sizes are stored on application exit and will be loaded on next launch.
+
+3) Close app and reopen — manual splitter positions persist
+	- Action: With manual splitter adjustments made, close the application and then relaunch it.
+	- Expected: The frames open with the splitters in the last positions the user set before exit.
+
+4) Re-setting the layout (re-selecting the currently selected layout)
+	- Action: Choose the currently-active layout again from the `Layout` menu.
+	- Expected: The layout fully resets and rebuilds; all frames are laid out evenly (default sizes). Persisted splitter sizes are NOT applied when re-selecting a layout.
+
+5) Changing to another layout
+	- Action: Select a different layout from the `Layout` menu.
+	- Expected: The layout switches and rebuilds. The new layout starts in default (evenly distributed) sizes. Persisted splitter sizes are only applied on application startup — not when changing layouts during a running session.
+
+6) Per-frame zoom persists
+	- Action: Use the `A-` / `A+` buttons (or the View menu actions) to change the zoom of a frame, quit the application, and relaunch it.
+	- Expected: Each frame reopens with the exact zoom factor that was active before quitting. Only the web content should change size; splitter handles and chrome stay put.
+
+Notes
+- Persisted splitter positions are only loaded once at application startup. During normal runtime, selecting or re-selecting layouts resets to default split positions.
+- The app persists splitter sizes on exit so they can be used for the next application launch.
+- Recommended: test quickly by resizing splitters, closing the app, and reopening to verify persistence.

--- a/SplitWindow.h
+++ b/SplitWindow.h
@@ -187,6 +187,15 @@ private slots:
    * Updates the addresses_ vector and persists to QSettings.
    */
   void onAddressEdited(SplitFrameWidget *who, const QString &text);
+
+  /**
+   * @brief Handles scale adjustments emitted by a frame.
+   * @param who The frame whose scale changed
+   * @param scale The new scale factor (1.0 = default)
+   *
+   * Persists the new scale and keeps the internal model synchronized.
+   */
+  void onFrameScaleChanged(SplitFrameWidget *who, double scale);
   
   /**
    * @brief Handles DevTools request from a frame.
@@ -240,6 +249,21 @@ private slots:
    */
   void onCloseShortcut();
 
+  /**
+   * @brief Increases the focused frame's scale (View menu action).
+   */
+  void increaseFocusedFrameScale();
+
+  /**
+   * @brief Decreases the focused frame's scale (View menu action).
+   */
+  void decreaseFocusedFrameScale();
+
+  /**
+   * @brief Resets the focused frame's scale back to 100%.
+   */
+  void resetFocusedFrameScale();
+
 protected:
   /**
    * @brief Handles window close events.
@@ -261,6 +285,14 @@ protected:
   void changeEvent(QEvent *event) override;
 
 private:
+  /**
+   * @brief Represents persisted per-frame state (address + scale).
+   */
+  struct FrameState {
+    QString address;  ///< Last loaded address
+    double scale = 1.0; ///< UI/content scale multiplier
+  };
+
   /**
    * @brief Converts a layout mode enum to a settings key string.
    * @param m The layout mode
@@ -302,9 +334,28 @@ private:
    */
   void onSplitterDoubleClickResized();
 
+  /**
+   * @brief Returns the currently focused SplitFrameWidget, if any.
+   */
+  SplitFrameWidget *focusedFrame() const;
+
+  /**
+   * @brief Looks up a frame's logical index based on its widget pointer.
+   * @param frame The SplitFrameWidget to look up
+   * @return Zero-based index or -1 if not found
+   */
+  int frameIndexFor(SplitFrameWidget *frame) const;
+
+  /**
+   * @brief Persists the shared frame state (addresses + scales) to root QSettings.
+   *
+   * Used for default window templates and backwards compatibility when no window ID is set.
+   */
+  void persistGlobalFrameState();
+
   QWidget *central_ = nullptr;              ///< Central widget containing the layout
   QVBoxLayout *layout_ = nullptr;           ///< Main vertical layout
-  std::vector<QString> addresses_;          ///< URL addresses for each frame
+  std::vector<FrameState> frames_;          ///< Per-frame address + scale state
   QWebEngineProfile *profile_ = nullptr;    ///< Shared web engine profile
   LayoutMode layoutMode_ = Vertical;        ///< Current layout mode
   std::vector<QSplitter*> currentSplitters_; ///< Active splitters for current layout


### PR DESCRIPTION
## Summary
- add a FrameState model that tracks both address and zoom, wire new View menu actions, and persist frame scale values alongside addresses
- expose A-/A+/1x controls on every frame, emit scaleChanged, and forward zoom changes to QWebEngineView without resizing the chrome
- document the new behavior in README/AGENTS and describe a manual test that verifies zoom persistence

Fixes #13.

## Testing
- not run (local environment is missing Qt6 SDK, so CMake configure fails with "Could not find a package configuration file provided by 'Qt6'")
