### PR TITLE
Add reload shortcuts with cache bypass support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,6 +47,8 @@ The application implements standard keyboard shortcuts for common operations:
 
 ### Frame Management Shortcuts
 - **Command-T** (macOS) / **Ctrl+T** (other platforms): Add new frame after the currently focused frame
+- **Command-R** (macOS) / **Ctrl+R** (other platforms): Reload the focused frame via the View ▸ Reload Frame action
+- **Command-Shift-R** (macOS) / **Ctrl+Shift+R** (other platforms): Reload the focused frame while bypassing cache via View ▸ Reload Frame (Bypass Cache)
 - **Command-N** (macOS) / **Ctrl+N** (other platforms): Open a new window
 - **F12**: Toggle DevTools for the focused frame
 - **Command-W** (macOS) / **Ctrl+W** (other platforms): Close window

--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ cmake --build . --config Release
 - **Remove Frame**: Click the `-` button on any frame to remove it (confirmation required)
 - **Reorder Frames**: Use the `↑` and `↓` buttons to move frames up or down
 - **Double-click any splitter handle** to instantly resize the two adjacent panes to equal sizes (50/50 split).
+- **Reload Frame**: Press `⌘R` (macOS) or `Ctrl+R` (other platforms) to reload the focused frame, or use `View -> Reload Frame`.
+- **Reload Frame (Bypass Cache)**: Press `⌘⇧R` (macOS) or `Ctrl+Shift+R` (other platforms) to force-refresh the focused frame via `View -> Reload Frame (Bypass Cache)`.
 
 ### Window Management
 - **New Window**: Press `⌘N` (Command-N on macOS) or `Ctrl+N` (other platforms)

--- a/SplitFrameWidget.h
+++ b/SplitFrameWidget.h
@@ -82,6 +82,12 @@ public:
   void updateNavButtons();
 
   /**
+   * @brief Reloads the current page optionally bypassing cache.
+   * @param bypassCache When true, forces network reload ignoring cached resources
+   */
+  void reload(bool bypassCache = false);
+
+  /**
    * @brief Event filter for the address line edit.
    * @param watched The object being watched
    * @param event The event to filter
@@ -206,7 +212,18 @@ signals:
    */
   void scaleChanged(SplitFrameWidget *who, double scale);
 
+  /**
+   * @brief Emitted whenever the user interacts with this frame.
+   * @param who Pointer to this frame widget
+   */
+  void interactionOccurred(SplitFrameWidget *who);
+
 private:
+  /**
+   * @brief Installs an event filter on a child widget to detect interactions.
+   */
+  void registerInteractionTarget(QWidget *child);
+
   QVBoxLayout *innerLayout_ = nullptr;  ///< Main layout for the frame
   QLineEdit *address_ = nullptr;        ///< Address bar for URL input
   MyWebEngineView *webview_ = nullptr;  ///< Web view content area

--- a/SplitWindow.h
+++ b/SplitWindow.h
@@ -119,6 +119,16 @@ private slots:
    * to the focused frame (or first frame if none focused) and shows it.
    */
   void toggleDevToolsForFocusedFrame();
+
+  /**
+   * @brief Reloads the focused frame using the standard cache-preserving reload.
+   */
+  void reloadFocusedFrame();
+
+  /**
+   * @brief Reloads the focused frame while bypassing the HTTP cache.
+   */
+  void reloadFocusedFrameBypassingCache();
   
   /**
    * @brief Adds a new frame after the currently focused frame.
@@ -215,6 +225,12 @@ private slots:
    * Opens the translation URL in a new SplitWindow.
    */
   void onFrameTranslateRequested(SplitFrameWidget *who, const QUrl &translateUrl);
+
+  /**
+   * @brief Updates focus heuristics when a frame reports user interaction.
+   * @param who The frame that was interacted with
+   */
+  void onFrameInteraction(SplitFrameWidget *who);
   
   /**
    * @brief Creates and attaches the shared DevTools view to a page.
@@ -335,9 +351,15 @@ private:
   void onSplitterDoubleClickResized();
 
   /**
-   * @brief Returns the currently focused SplitFrameWidget, if any.
+   * @brief Finds the focused SplitFrameWidget or falls back to the first frame.
+   * @return Pointer to the focused frame, or the first frame if none focused
    */
-  SplitFrameWidget *focusedFrame() const;
+  SplitFrameWidget *focusedFrameOrFirst() const;
+
+  /**
+   * @brief Returns the first frame in logical order, if available.
+   */
+  SplitFrameWidget *firstFrameWidget() const;
 
   /**
    * @brief Looks up a frame's logical index based on its widget pointer.
@@ -363,4 +385,5 @@ private:
   bool restoredOnStartup_ = false;          ///< Whether state was restored on construction
   QString windowId_;                        ///< Unique ID for this window instance
   QMenu *windowMenu_ = nullptr;             ///< The Window menu for this window
+  SplitFrameWidget *lastFocusedFrame_ = nullptr; ///< Tracks the most recently focused frame
 };


### PR DESCRIPTION
## Summary
- add programmable reload helpers and expose Cmd/Ctrl+R plus Cmd/Ctrl+Shift+R shortcuts from the View menu so the focused frame can refresh with or without bypassing cache
- track the most recently interacted frame (including button clicks and scale widgets) so reload shortcuts always target the correct pane, even when Qt focus isn’t on the web view
- document the new shortcuts in README.md and AGENTS.md for both users and agent workflows

## Testing
- Not run (not requested)

Fixes #43.